### PR TITLE
Probably meant Node as Tree type is not defined

### DIFF
--- a/2021/03/09/creating-an-iterator.html
+++ b/2021/03/09/creating-an-iterator.html
@@ -180,7 +180,7 @@
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="rust"><span class="k">struct</span> <span class="n">NodeIter</span><span class="o">&lt;</span><span class="nv">'a</span><span class="p">,</span> <span class="n">It</span><span class="o">&gt;</span><span class="p">(</span><span class="o">&amp;</span><span class="nv">'a</span> <span class="n">Tree</span><span class="o">&lt;</span><span class="n">It</span><span class="o">&gt;</span><span class="p">);</span></code></pre>
+<pre class="rouge highlight"><code data-lang="rust"><span class="k">struct</span> <span class="n">NodeIter</span><span class="o">&lt;</span><span class="nv">'a</span><span class="p">,</span> <span class="n">It</span><span class="o">&gt;</span><span class="p">(</span><span class="o">&amp;</span><span class="nv">'a</span> <span class="n">Node</span><span class="o">&lt;</span><span class="n">It</span><span class="o">&gt;</span><span class="p">);</span></code></pre>
 </div>
 </div>
 <div class="openblock hint">


### PR DESCRIPTION
...unless you had an alias in mind?

```rust
type Tree<It> = Node<It>;
```